### PR TITLE
Modify extrapolation

### DIFF
--- a/wofs_phi/config.py
+++ b/wofs_phi/config.py
@@ -30,7 +30,7 @@ min_radius = 1.5 #in km (for probSevere objects)
 
 #radius (in km) for probSevere objects at the maximum extrapolation time 
 #generally taken to be 181 minutes. 
-max_radius = 1.5 #in km (for probSevere objects) #Used to be 30.0, but that was much too big
+max_radius = 20.0 #in km (for probSevere objects) #Used to be 30.0, but that was much too big
 
 
 conv_type = "square" #"square" or "circle" -- tells how to do the convolutions 

--- a/wofs_phi/config.py
+++ b/wofs_phi/config.py
@@ -30,8 +30,8 @@ min_radius = 1.5 #in km (for probSevere objects)
 
 #radius (in km) for probSevere objects at the maximum extrapolation time 
 #generally taken to be 181 minutes. 
-max_radius = 20.0 #in km (for probSevere objects) #Used to be 30.0, but that was much too big
-
+#max_radius = 20.0 #in km (for probSevere objects) #Used to be 30.0, but that was much too big
+max_radius = 1.5 
 
 conv_type = "square" #"square" or "circle" -- tells how to do the convolutions 
 predictor_radii_km = [0.0, 15.0, 30.0, 45.0, 60.0] #how far to "look" spatially in km for predictors

--- a/wofs_phi/wofs_phi.py
+++ b/wofs_phi/wofs_phi.py
@@ -221,6 +221,10 @@ class PS:
             @xarr is an xarray of all the relevant predictors
         '''
 
+        #TODO: Could add a list of past ProbSevereObject objects, and a list of 
+        #current ProbSevereObject objects. 
+
+
         self.gdf = gdf
         self.xarr = xarr
         
@@ -238,7 +242,11 @@ class PS:
             Ultimately creates a PS object with a gdf and xarrray of the relevant predictors 
         '''
 
-        #Current procedure: #TODO
+        #TODO (potential): Could create new class: ProbSevereObject, where each literal ProbSevere
+        #object is an object, and we set all the variables we want to extract. Then we'd have 1 method
+        #to convert this to a dataframe/geodataframe. Might be worth doing. So in the end we'd get
+        #a list of past ProbSevereObject objects and a list of current ProbSevereObject objects. 
+
         #Get a dataframe of all past objects (including their IDs, hazard probabilities, and ages) 
         past_ps_df = PS.get_past_ps_df(specs, ps_path, ps_files)
 


### PR DESCRIPTION
Updated extrapolation so we don't have to extrapolate the full, e.g., 181 minutes, but can stop after the PS lead time of the end of the forecast valid period. 